### PR TITLE
Fix image location

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: descheduler-operator
-          image: docker.io/ravig/descheduler-operator:v0.0.7
+          image: registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler-operator
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
This should fix the descheduler issue:

`E1123 08:56:08.384453       1 reflector.go:205] github.com/openshift/descheduler-operator/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1alpha1.Descheduler: v1alpha1.DeschedulerList.Items: []v1alpha1.Descheduler: v1alpha1.Descheduler.Spec: v1alpha1.DeschedulerSpec.Strategies: []string: ReadString: expects " or n, but found {, error found in #10 byte of ...|tegies":[{"name":"lo|..., bigger context ...|8-11e8-835e-0e6542778c90"},"spec":{"strategies":[{"name":"lownodeutilization","params":[{"name":"cpu|...`