### PR TITLE
Update readme with role and role binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ To deploy the operator:
 ```
 oc create -f deploy/ns.yaml
 oc create -f deploy/crd.yaml
-oc create -f deploy/rbac.yaml
+oc create -f deploy/role.yaml
+oc create -f deploy/role_binding.yaml
 oc create -f deploy/operator.yaml
 oc create -f deploy/cr.yaml
 ```


### PR DESCRIPTION
operator-sdk started using role and role_binding. We should start using them instead of single rbac.yaml