### PR TITLE
Expose image to be managed by descheduler operator

### DIFF
--- a/pkg/apis/descheduler/v1alpha1/descheduler_types.go
+++ b/pkg/apis/descheduler/v1alpha1/descheduler_types.go
@@ -15,6 +15,8 @@ type DeschedulerSpec struct {
 	Schedule string `json:"schedule,omitempty"`
 	// Flags for descheduler.
 	Flags []Param `json:"Flags"`
+	// Image of the deschduler being managed. This includes the version of the operand(descheduler).
+	Image string `json:"image, omitempty"`
 }
 
 // Strategy supported by descheduler

--- a/pkg/controller/descheduler/descheduler_controller.go
+++ b/pkg/controller/descheduler/descheduler_controller.go
@@ -28,7 +28,7 @@ import (
 const (
 	Running      = "RunningPhase"
 	Updating     = "UpdatingPhase"
-	defaultImage = "registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler"
+	DefaultImage = "quay.io/openshift/origin-descheduler:latest"
 )
 
 // array of valid strategies. TODO: Make this map(or set) once we have lot of strategies.
@@ -442,7 +442,7 @@ func (r *ReconcileDescheduler) createCronJob(descheduler *deschedulerv1alpha1.De
 	}
 	if len(descheduler.Spec.Image) == 0 {
 		// Set the default image here
-		descheduler.Spec.Image = defaultImage // No need to update the CR here making it opaque to end-user
+		descheduler.Spec.Image = DefaultImage // No need to update the CR here making it opaque to end-user
 	}
 	flags = append(DeschedulerCommand, flags...)
 	job := &batchv1beta1.CronJob{


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1666649

As of now, we are not exposing the information related to descheduler image being managed by operator, this PR should help in fixing it.

/cc @sjenning 
