### PR TITLE
Set namespace in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ apiVersion: descheduler.io/v1alpha1
 kind: Descheduler
 metadata:
   name: example-descheduler-1
+  namespace: openshift-operators
 spec:
   schedule: "*/1 * * * ?"
   strategies: 


### PR DESCRIPTION
Descheduler is being installed in `openshift-operators` namespace
(it doesn't seem to be configurable), so an example CRD should use that.

Without namespace set the error message is "Not Found", which is not
helping much